### PR TITLE
Fix(doc): long options typo in man page

### DIFF
--- a/doc/kwim.1
+++ b/doc/kwim.1
@@ -5,7 +5,7 @@
 .nh
 .ad l
 .\" Begin generated content:
-.TH "KWIM" "1" "2026-04-05" "kwim" "kwm input manager"
+.TH "KWIM" "1" "2026-04-15" "kwim" "kwm input manager"
 .PP
 .SH NAME
 .PP
@@ -36,17 +36,17 @@ configuration file used by \fIkwm\fR.\&
 .PP
 .SH OPTIONS
 .PP
-\fB-h,-help\fR
+\fB-h,--help\fR
 .RS 4
 Print a help message and exit.\&
 .PP
 .RE
-\fB-v,-version\fR
+\fB-v,--version\fR
 .RS 4
 Print the version and exit.\&
 .PP
 .RE
-\fB-c,-config\fR
+\fB-c,--config\fR
 .RS 4
 Specify the configuration file path.\&
 .PP

--- a/doc/kwim.1.scd
+++ b/doc/kwim.1.scd
@@ -27,13 +27,13 @@ configuration file used by _kwm_.
 
 # OPTIONS
 
-*-h,-help*
+*-h,--help*
 	Print a help message and exit.
 
-*-v,-version*
+*-v,--version*
 	Print the version and exit.
 
-*-c,-config*
+*-c,--config*
 	Specify the configuration file path.
 
 # SUBCOMMANDS


### PR DESCRIPTION
Match the actual command line options.