### PR TITLE
github: remove render property from logs

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug.yml
@@ -59,6 +59,5 @@ body:
         ```
 
         Reproduce your problem and exit river.
-      render: shell
     validations:
       required: false


### PR DESCRIPTION
This would leave an empty block if there's no input, or break user defined syntax.