### PR TITLE
fix(xkb_keyboard): arena_allocator type mismatch

### DIFF
--- a/src/kwim/xkb_keyboard.zig
+++ b/src/kwim/xkb_keyboard.zig
@@ -201,7 +201,7 @@ fn set_keymap(self: *Self, keymap: *const Keymap) !void {
             const xkb_context = xkbcommon.Context.new(.no_flags) orelse return error.XkbContextNewFailed;
             defer xkb_context.unref();
 
-            const arena_allocator: heap.ArenaAllocator = .init(ctx.gpa);
+            var arena_allocator: heap.ArenaAllocator = .init(ctx.gpa);
             defer arena_allocator.deinit();
             const arena = arena_allocator.allocator();
 


### PR DESCRIPTION
`ArenaAllocator.allocator()` expects `*ArenaAllocator`, but a const variable produces `*const ArenaAllocator`.

This fixed a compilation failure from commit 5c379ffadd4cc7ec1acb5cd32d39a2ab26a20a08.